### PR TITLE
Some refactoring and cleanup, migrate from winapi to windows_sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ categories = ["network-programming"]
 license = "MIT"
 
 [dependencies]
-socket2 = { version = "0.4.4", features = ["all"] }
+# socket2 = { version = "0.4.4", features = ["all"] }
+socket2 = {git = "https://github.com/rust-lang/socket2", features=["all"], rev = "f9c1aef5"}
 pnet_packet = "0.29.0"
-dns-lookup = "1.0"
+# dns-lookup = "1.0"
+dns-lookup = {git = "https://github.com/sn99/dns-lookup.git", rev = "7bda2a2"}
 default-net = "0.11.0"
 rand = "0.8.5"
 
-[target.'cfg(windows)'.dependencies]
-winapi = "0.3.9"
+[target."cfg(windows)".dependencies]
+windows-sys = {version = "0.36.1", features = ["Win32_Networking_WinSock", "Win32_Foundation", "Win32_System_WindowsProgramming"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["shellrow <shellrow@protonmail.com>"]
 description = "Cross-platform library for traceroute and ping"
 repository = "https://github.com/shellrow/tracert"
 readme = "README.md"
-keywords = ["network"]
+keywords = ["network", "tracetoute", "ping"]
 categories = ["network-programming"]
 license = "MIT"
 

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr};
-use tracert::ping::Pinger;
 use std::thread;
+use tracert::ping::Pinger;
 
 fn main() {
     // ICMP ping to scanme.nmap.org (45.33.32.156)
@@ -8,9 +8,7 @@ fn main() {
     let pinger: Pinger = Pinger::new(dst_ip).unwrap();
     let rx = pinger.get_progress_receiver();
     // Run ping
-    let handle = thread::spawn(move|| {
-        pinger.ping()
-    });
+    let handle = thread::spawn(move || pinger.ping());
     // Print progress
     println!("Progress:");
     while let Ok(msg) = rx.lock().unwrap().recv() {
@@ -25,7 +23,7 @@ fn main() {
                 println!("{:?}", result);
             }
             println!("Probe Time: {:?}", r.probe_time);
-        },
+        }
         Err(e) => {
             print!("{}", e);
         }

--- a/examples/traceroute.rs
+++ b/examples/traceroute.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr};
-use tracert::trace::Tracer;
 use std::thread;
+use tracert::trace::Tracer;
 
 fn main() {
     // UDP traceroute to scanme.nmap.org (45.33.32.156)
@@ -8,9 +8,7 @@ fn main() {
     let tracer: Tracer = Tracer::new(dst_ip).unwrap();
     let rx = tracer.get_progress_receiver();
     // Run trace
-    let handle = thread::spawn(move|| {
-        tracer.trace()
-    });
+    let handle = thread::spawn(move || tracer.trace());
     // Print progress
     println!("Progress:");
     while let Ok(msg) = rx.lock().unwrap().recv() {
@@ -25,7 +23,7 @@ fn main() {
                 println!("{:?}", node);
             }
             println!("Trace Time: {:?}", r.probe_time);
-        },
+        }
         Err(e) => {
             print!("{}", e);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-mod sys;
-mod packet;
-pub mod protocol;
 pub mod node;
-pub mod trace;
+mod packet;
 pub mod ping;
+pub mod protocol;
+mod sys;
+pub mod trace;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 use std::time::Duration;
 
-/// Node type 
+/// Node type
 #[derive(Clone, Debug)]
 pub enum NodeType {
     /// Default gateway

--- a/src/packet/icmpv4.rs
+++ b/src/packet/icmpv4.rs
@@ -1,11 +1,11 @@
-use pnet_packet::Packet;
 use pnet_packet::icmp::echo_request::MutableEchoRequestPacket;
 use pnet_packet::icmp::IcmpTypes;
+use pnet_packet::Packet;
 
-pub fn build_icmpv4_packet(icmp_packet:&mut MutableEchoRequestPacket) {
+pub fn build_icmpv4_packet(icmp_packet: &mut MutableEchoRequestPacket) {
     icmp_packet.set_icmp_type(IcmpTypes::EchoRequest);
     icmp_packet.set_sequence_number(rand::random::<u16>());
     icmp_packet.set_identifier(rand::random::<u16>());
-    let icmp_check_sum = pnet_packet::util::checksum(&icmp_packet.packet(), 1);
+    let icmp_check_sum = pnet_packet::util::checksum(icmp_packet.packet(), 1);
     icmp_packet.set_checksum(icmp_check_sum);
 }

--- a/src/packet/icmpv6.rs
+++ b/src/packet/icmpv6.rs
@@ -1,10 +1,10 @@
-use pnet_packet::Packet;
-use pnet_packet::icmpv6::MutableIcmpv6Packet;
 use pnet_packet::icmpv6::Icmpv6Types;
+use pnet_packet::icmpv6::MutableIcmpv6Packet;
+use pnet_packet::Packet;
 
 #[allow(dead_code)]
-pub fn build_icmpv6_packet(icmp_packet:&mut MutableIcmpv6Packet) {
+pub fn build_icmpv6_packet(icmp_packet: &mut MutableIcmpv6Packet) {
     icmp_packet.set_icmpv6_type(Icmpv6Types::EchoRequest);
-    let icmp_check_sum = pnet_packet::util::checksum(&icmp_packet.packet(), 1);
+    let icmp_check_sum = pnet_packet::util::checksum(icmp_packet.packet(), 1);
     icmp_packet.set_checksum(icmp_check_sum);
 }

--- a/src/packet/ipv4.rs
+++ b/src/packet/ipv4.rs
@@ -1,12 +1,17 @@
-use std::net::Ipv4Addr;
 use pnet_packet::ip::{IpNextHeaderProtocol, IpNextHeaderProtocols};
-use pnet_packet::ipv4::{MutableIpv4Packet, Ipv4Flags};
+use pnet_packet::ipv4::{Ipv4Flags, MutableIpv4Packet};
+use std::net::Ipv4Addr;
 
 #[allow(dead_code)]
 pub const IPV4_HEADER_LEN: usize = 20;
 
 #[allow(dead_code)]
-pub fn build_ipv4_packet(ipv4_packet: &mut MutableIpv4Packet, src_ip: Ipv4Addr, dst_ip: Ipv4Addr, next_protocol: IpNextHeaderProtocol) {
+pub fn build_ipv4_packet(
+    ipv4_packet: &mut MutableIpv4Packet,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    next_protocol: IpNextHeaderProtocol,
+) {
     ipv4_packet.set_header_length(69);
     ipv4_packet.set_total_length(52);
     ipv4_packet.set_source(src_ip);
@@ -18,14 +23,14 @@ pub fn build_ipv4_packet(ipv4_packet: &mut MutableIpv4Packet, src_ip: Ipv4Addr, 
     match next_protocol {
         IpNextHeaderProtocols::Tcp => {
             ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Tcp);
-        },
+        }
         IpNextHeaderProtocols::Udp => {
             ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Udp);
-        },
+        }
         IpNextHeaderProtocols::Icmp => {
             ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Icmp);
-        },
-        _ => {},
+        }
+        _ => {}
     }
     let checksum = pnet_packet::ipv4::checksum(&ipv4_packet.to_immutable());
     ipv4_packet.set_checksum(checksum);

--- a/src/packet/ipv6.rs
+++ b/src/packet/ipv6.rs
@@ -1,25 +1,30 @@
-use std::net::Ipv6Addr;
 use pnet_packet::ip::{IpNextHeaderProtocol, IpNextHeaderProtocols};
-use pnet_packet::ipv6::{MutableIpv6Packet};
+use pnet_packet::ipv6::MutableIpv6Packet;
+use std::net::Ipv6Addr;
 
 #[allow(dead_code)]
 pub const IPV6_HEADER_LEN: usize = 40;
 
 #[allow(dead_code)]
-pub fn build_ipv6_packet(ipv6_packet: &mut MutableIpv6Packet, src_ip: Ipv6Addr, dst_ip: Ipv6Addr, next_protocol: IpNextHeaderProtocol) {
+pub fn build_ipv6_packet(
+    ipv6_packet: &mut MutableIpv6Packet,
+    src_ip: Ipv6Addr,
+    dst_ip: Ipv6Addr,
+    next_protocol: IpNextHeaderProtocol,
+) {
     ipv6_packet.set_source(src_ip);
     ipv6_packet.set_destination(dst_ip);
     ipv6_packet.set_version(6);
     match next_protocol {
         IpNextHeaderProtocols::Tcp => {
             ipv6_packet.set_next_header(IpNextHeaderProtocols::Tcp);
-        },
+        }
         IpNextHeaderProtocols::Udp => {
             ipv6_packet.set_next_header(IpNextHeaderProtocols::Udp);
-        },
+        }
         IpNextHeaderProtocols::Icmp => {
             ipv6_packet.set_next_header(IpNextHeaderProtocols::Icmp);
-        },
-        _ => {},
+        }
+        _ => {}
     }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -1,7 +1,7 @@
-mod ipv4;
-mod ipv6;
 mod icmpv4;
 mod icmpv6;
+mod ipv4;
+mod ipv6;
 mod tcp;
 mod udp;
 
@@ -15,7 +15,8 @@ const IPV4_HEADER_LEN: usize = 20;
 
 pub fn build_icmpv4_echo_packet() -> Vec<u8> {
     let mut buf = vec![0; 16];
-    let mut icmp_packet = pnet_packet::icmp::echo_request::MutableEchoRequestPacket::new(&mut buf[..]).unwrap();
+    let mut icmp_packet =
+        pnet_packet::icmp::echo_request::MutableEchoRequestPacket::new(&mut buf[..]).unwrap();
     icmpv4::build_icmpv4_packet(&mut icmp_packet);
     icmp_packet.packet().to_vec()
 }
@@ -29,17 +30,33 @@ pub fn build_icmpv6_echo_packet() -> Vec<u8> {
 }
 
 #[allow(dead_code)]
-pub fn build_tcp_syn_packet(src_ip: IpAddr, src_port: u16, dst_ip: IpAddr, dst_port: u16) -> Vec<u8> {
+pub fn build_tcp_syn_packet(
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+) -> Vec<u8> {
     let mut vec: Vec<u8> = vec![0; 66];
-    let mut tcp_packet = pnet_packet::tcp::MutableTcpPacket::new(&mut vec[(ETHERNET_HEADER_LEN + IPV4_HEADER_LEN)..]).unwrap();
+    let mut tcp_packet = pnet_packet::tcp::MutableTcpPacket::new(
+        &mut vec[(ETHERNET_HEADER_LEN + IPV4_HEADER_LEN)..],
+    )
+    .unwrap();
     tcp::build_tcp_packet(&mut tcp_packet, src_ip, src_port, dst_ip, dst_port);
     tcp_packet.packet().to_vec()
 }
 
 #[allow(dead_code)]
-pub fn build_udp_probe_packet(src_ip: IpAddr, src_port: u16, dst_ip: IpAddr, dst_port: u16) -> Vec<u8> {
+pub fn build_udp_probe_packet(
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+) -> Vec<u8> {
     let mut vec: Vec<u8> = vec![0; 66];
-    let mut udp_packet = pnet_packet::udp::MutableUdpPacket::new(&mut vec[(ETHERNET_HEADER_LEN + IPV4_HEADER_LEN)..]).unwrap();
+    let mut udp_packet = pnet_packet::udp::MutableUdpPacket::new(
+        &mut vec[(ETHERNET_HEADER_LEN + IPV4_HEADER_LEN)..],
+    )
+    .unwrap();
     udp::build_udp_packet(&mut udp_packet, src_ip, src_port, dst_ip, dst_port);
     udp_packet.packet().to_vec()
 }

--- a/src/packet/tcp.rs
+++ b/src/packet/tcp.rs
@@ -1,36 +1,42 @@
+use pnet_packet::tcp::{MutableTcpPacket, TcpFlags, TcpOption};
 use std::net::IpAddr;
-use pnet_packet::tcp::{MutableTcpPacket, TcpOption, TcpFlags};
 
-pub fn build_tcp_packet(tcp_packet:&mut MutableTcpPacket, src_ip: IpAddr, src_port:u16, dst_ip: IpAddr, dst_port:u16) {
+pub fn build_tcp_packet(
+    tcp_packet: &mut MutableTcpPacket,
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+) {
     tcp_packet.set_source(src_port);
     tcp_packet.set_destination(dst_port);
     tcp_packet.set_window(64240);
     tcp_packet.set_data_offset(8);
     tcp_packet.set_urgent_ptr(0);
     tcp_packet.set_sequence(0);
-    tcp_packet.set_options(&[TcpOption::mss(1460)
-    , TcpOption::sack_perm()
-    , TcpOption::nop()
-    , TcpOption::nop()
-    , TcpOption::wscale(7)]);
+    tcp_packet.set_options(&[
+        TcpOption::mss(1460),
+        TcpOption::sack_perm(),
+        TcpOption::nop(),
+        TcpOption::nop(),
+        TcpOption::wscale(7),
+    ]);
     tcp_packet.set_flags(TcpFlags::SYN);
     match src_ip {
-        IpAddr::V4(src_ip) => {
-            match dst_ip {
-                IpAddr::V4(dst_ip) => {
-                    let checksum = pnet_packet::tcp::ipv4_checksum(&tcp_packet.to_immutable(), &src_ip, &dst_ip);
-                    tcp_packet.set_checksum(checksum);
-                },
-                IpAddr::V6(_) => {},
+        IpAddr::V4(src_ip) => match dst_ip {
+            IpAddr::V4(dst_ip) => {
+                let checksum =
+                    pnet_packet::tcp::ipv4_checksum(&tcp_packet.to_immutable(), &src_ip, &dst_ip);
+                tcp_packet.set_checksum(checksum);
             }
+            IpAddr::V6(_) => {}
         },
-        IpAddr::V6(src_ip) => {
-            match dst_ip {
-                IpAddr::V4(_) => {},
-                IpAddr::V6(dst_ip) => {
-                    let checksum = pnet_packet::tcp::ipv6_checksum(&tcp_packet.to_immutable(), &src_ip, &dst_ip);
-                    tcp_packet.set_checksum(checksum);
-                },
+        IpAddr::V6(src_ip) => match dst_ip {
+            IpAddr::V4(_) => {}
+            IpAddr::V6(dst_ip) => {
+                let checksum =
+                    pnet_packet::tcp::ipv6_checksum(&tcp_packet.to_immutable(), &src_ip, &dst_ip);
+                tcp_packet.set_checksum(checksum);
             }
         },
     }

--- a/src/packet/udp.rs
+++ b/src/packet/udp.rs
@@ -1,27 +1,31 @@
-use std::net::IpAddr;
 use pnet_packet::udp::MutableUdpPacket;
+use std::net::IpAddr;
 
-pub fn build_udp_packet(udp_packet:&mut MutableUdpPacket, src_ip: IpAddr, src_port:u16, dst_ip: IpAddr, dst_port:u16) {
+pub fn build_udp_packet(
+    udp_packet: &mut MutableUdpPacket,
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+) {
     udp_packet.set_length(8);
     udp_packet.set_source(src_port);
     udp_packet.set_destination(dst_port);
     match src_ip {
-        IpAddr::V4(src_ip) => {
-            match dst_ip {
-                IpAddr::V4(dst_ip) => {
-                    let checksum = pnet_packet::udp::ipv4_checksum(&udp_packet.to_immutable(), &src_ip, &dst_ip);
-                    udp_packet.set_checksum(checksum);
-                },
-                IpAddr::V6(_) => {},
+        IpAddr::V4(src_ip) => match dst_ip {
+            IpAddr::V4(dst_ip) => {
+                let checksum =
+                    pnet_packet::udp::ipv4_checksum(&udp_packet.to_immutable(), &src_ip, &dst_ip);
+                udp_packet.set_checksum(checksum);
             }
+            IpAddr::V6(_) => {}
         },
-        IpAddr::V6(src_ip) => {
-            match dst_ip {
-                IpAddr::V4(_) => {},
-                IpAddr::V6(dst_ip) => {
-                    let checksum = pnet_packet::udp::ipv6_checksum(&udp_packet.to_immutable(), &src_ip, &dst_ip);
-                    udp_packet.set_checksum(checksum);
-                },
+        IpAddr::V6(src_ip) => match dst_ip {
+            IpAddr::V4(_) => {}
+            IpAddr::V6(dst_ip) => {
+                let checksum =
+                    pnet_packet::udp::ipv6_checksum(&udp_packet.to_immutable(), &src_ip, &dst_ip);
+                udp_packet.set_checksum(checksum);
             }
         },
     }

--- a/src/ping/mod.rs
+++ b/src/ping/mod.rs
@@ -1,23 +1,23 @@
-#[cfg(not(target_os="windows"))]
+#[cfg(not(target_os = "windows"))]
 mod unix;
-#[cfg(not(target_os="windows"))]
+#[cfg(not(target_os = "windows"))]
 use unix::ping;
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 mod windows;
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 use self::windows::ping;
 
 mod pinger;
 pub use pinger::*;
 
-use std::time::Duration;
 use crate::node::Node;
+use std::time::Duration;
 
 /// Exit status of ping
 #[derive(Clone, Debug)]
 pub enum PingStatus {
-    /// Successfully completed 
+    /// Successfully completed
     Done,
     /// Interrupted by error
     Error,

--- a/src/ping/pinger.rs
+++ b/src/ping/pinger.rs
@@ -1,13 +1,13 @@
-use std::net::IpAddr;
-use std::time::Duration;
-use std::sync::{Mutex, Arc};
-use std::sync::mpsc::{channel ,Sender, Receiver};
 use super::PingResult;
-use crate::protocol::Protocol;
 use crate::node::Node;
+use crate::protocol::Protocol;
+use std::net::IpAddr;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 /// Pinger structure
-/// 
+///
 /// Contains various settings for ping
 #[derive(Clone, Debug)]
 pub struct Pinger {
@@ -15,16 +15,16 @@ pub struct Pinger {
     pub src_ip: IpAddr,
     /// Destination IP address
     pub dst_ip: IpAddr,
-    /// Destination port 
+    /// Destination port
     pub dst_port: u16,
     /// Protocol used for PING
     pub protocol: Protocol,
     /// Time to live
-    /// 
+    ///
     /// Default is 64
     pub ttl: u8,
     /// Ping execution count
-    /// 
+    ///
     /// Default is 4
     pub count: u8,
     /// Timeout setting for ping   
@@ -42,22 +42,19 @@ pub struct Pinger {
 impl Pinger {
     /// Create new Pinger instance with destination IP address
     pub fn new(dst_ip: IpAddr) -> Result<Pinger, String> {
-        match default_net::get_default_interface(){
+        match default_net::get_default_interface() {
             Ok(interface) => {
-                let src_ip: IpAddr = 
-                if interface.ipv4.len() > 0 {
+                let src_ip: IpAddr = if !interface.ipv4.is_empty() {
                     IpAddr::V4(interface.ipv4[0].addr)
-                }else{
-                    if interface.ipv6.len() > 0 {
-                        IpAddr::V6(interface.ipv6[0].addr)
-                    }else{
-                        return Err(String::from("Failed to get default interface"));
-                    }
+                } else if !interface.ipv6.is_empty() {
+                    IpAddr::V6(interface.ipv6[0].addr)
+                } else {
+                    return Err(String::from("Failed to get default interface"));
                 };
                 let (tx, rx) = channel();
                 let pinger = Pinger {
-                    src_ip: src_ip,
-                    dst_ip: dst_ip,
+                    src_ip,
+                    dst_ip,
                     dst_port: 0,
                     protocol: Protocol::Icmpv4,
                     ttl: 64,
@@ -68,11 +65,9 @@ impl Pinger {
                     tx: Arc::new(Mutex::new(tx)),
                     rx: Arc::new(Mutex::new(rx)),
                 };
-                return Ok(pinger);
-            },
-            Err(e) => {
-                return Err(format!("{}",e));
-            },
+                Ok(pinger)
+            }
+            Err(e) => Err(e),
         }
     }
     /// Run ping
@@ -80,7 +75,7 @@ impl Pinger {
         super::ping(self.clone(), &self.tx)
     }
     /// Set source IP address
-    pub fn set_src_ip(&mut self, src_ip: IpAddr){
+    pub fn set_src_ip(&mut self, src_ip: IpAddr) {
         self.src_ip = src_ip;
     }
     /// Get source IP address
@@ -88,7 +83,7 @@ impl Pinger {
         self.src_ip
     }
     /// Set destination IP address
-    pub fn set_dst_ip(&mut self, dst_ip: IpAddr){
+    pub fn set_dst_ip(&mut self, dst_ip: IpAddr) {
         self.dst_ip = dst_ip;
     }
     /// Get destination IP address
@@ -96,7 +91,7 @@ impl Pinger {
         self.dst_ip
     }
     /// Set destination port
-    pub fn set_dst_port(&mut self, dst_port: u16){
+    pub fn set_dst_port(&mut self, dst_port: u16) {
         self.dst_port = dst_port;
     }
     /// Get destination port
@@ -104,7 +99,7 @@ impl Pinger {
         self.dst_port
     }
     /// Set protocol
-    pub fn set_protocol(&mut self, protocol: Protocol){
+    pub fn set_protocol(&mut self, protocol: Protocol) {
         self.protocol = protocol;
     }
     /// Get protocol
@@ -112,7 +107,7 @@ impl Pinger {
         self.protocol.clone()
     }
     /// Set Time to live
-    pub fn set_ttl(&mut self, ttl: u8){
+    pub fn set_ttl(&mut self, ttl: u8) {
         self.ttl = ttl;
     }
     /// Get Time to live
@@ -120,7 +115,7 @@ impl Pinger {
         self.ttl
     }
     /// Set ping execution count
-    pub fn set_count(&mut self, count: u8){
+    pub fn set_count(&mut self, count: u8) {
         self.ttl = count;
     }
     /// Get ping execution count
@@ -128,7 +123,7 @@ impl Pinger {
         self.count
     }
     /// Set ping timeout
-    pub fn set_ping_timeout(&mut self, ping_timeout: Duration){
+    pub fn set_ping_timeout(&mut self, ping_timeout: Duration) {
         self.ping_timeout = ping_timeout;
     }
     /// Get ping timeout
@@ -136,7 +131,7 @@ impl Pinger {
         self.ping_timeout
     }
     /// Set packet receive timeout
-    pub fn set_receive_timeout(&mut self, receive_timeout: Duration){
+    pub fn set_receive_timeout(&mut self, receive_timeout: Duration) {
         self.receive_timeout = receive_timeout;
     }
     /// Get packet receive timeout
@@ -144,7 +139,7 @@ impl Pinger {
         self.receive_timeout
     }
     /// Set packet send rate
-    pub fn set_send_rate(&mut self, send_rate: Duration){
+    pub fn set_send_rate(&mut self, send_rate: Duration) {
         self.send_rate = send_rate;
     }
     /// Get packet send rate

--- a/src/ping/unix.rs
+++ b/src/ping/unix.rs
@@ -1,108 +1,98 @@
-use std::time::{Instant, Duration};
-use std::net::{SocketAddr, IpAddr, UdpSocket};
-use std::mem::MaybeUninit;
-use std::thread;
-use std::sync::{Mutex, Arc};
-use std::sync::mpsc::Sender;
-use socket2::{Domain, Protocol, Socket, Type, SockAddr};
-use pnet_packet::Packet;
-use pnet_packet::icmp::IcmpTypes;
-use crate::node::{NodeType, Node};
+use super::{PingResult, PingStatus, Pinger};
+use crate::node::{Node, NodeType};
 use crate::packet;
-use super::{Pinger, PingStatus, PingResult};
 use crate::protocol::Protocol as ProbeProtocol;
-use crate::trace::BASE_DST_PORT;
 use crate::sys;
+use crate::trace::BASE_DST_PORT;
+use pnet_packet::icmp::IcmpTypes;
+use pnet_packet::Packet;
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use std::mem::MaybeUninit;
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
 fn icmp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
-    let host_name: String = dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or(pinger.dst_ip.to_string());
+    let host_name: String =
+        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or_else(|_| pinger.dst_ip.to_string());
     let mut results: Vec<Node> = vec![];
-    let icmp_socket: Socket = 
-    if pinger.src_ip.is_ipv4() {
+    let icmp_socket: Socket = if pinger.src_ip.is_ipv4() {
         Socket::new(Domain::IPV4, Type::RAW, Some(Protocol::ICMPV4)).unwrap()
-    }else if pinger.src_ip.is_ipv6(){
+    } else if pinger.src_ip.is_ipv6() {
         Socket::new(Domain::IPV6, Type::RAW, Some(Protocol::ICMPV6)).unwrap()
-    }else{
+    } else {
         return Err(String::from("invalid source address"));
     };
-    icmp_socket.set_read_timeout(Some(pinger.receive_timeout)).unwrap();
+    icmp_socket
+        .set_read_timeout(Some(pinger.receive_timeout))
+        .unwrap();
     icmp_socket.set_ttl(pinger.ttl as u32).unwrap();
     let socket_addr = SocketAddr::new(pinger.dst_ip, 0);
     let sock_addr = SockAddr::from(socket_addr);
-    let mut icmp_packet: Vec<u8> = packet::build_icmpv4_echo_packet();
+    let icmp_packet: Vec<u8> = packet::build_icmpv4_echo_packet();
     let start_time = Instant::now();
     let mut probe_time = Duration::from_millis(0);
     for seq in 1..pinger.count + 1 {
         probe_time = Instant::now().duration_since(start_time);
         if probe_time > pinger.ping_timeout {
             let result: PingResult = PingResult {
-                results: results,
+                results,
                 status: PingStatus::Timeout,
-                probe_time: probe_time,
+                probe_time,
             };
             return Ok(result);
         }
         let mut buf: Vec<u8> = vec![0; 512];
-        let mut recv_buf = unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        let recv_buf = unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
         let send_time = Instant::now();
-        match icmp_socket.send_to(&mut icmp_packet, &sock_addr) {
-            Ok(_) => {},
-            Err(_) => {},
-        }
+        if icmp_socket.send_to(&icmp_packet, &sock_addr).is_ok() {}
         loop {
-            match icmp_socket.recv_from(&mut recv_buf) {
-                Ok((bytes_len, _addr)) => {
-                    let recv_time = Instant::now().duration_since(send_time);
-                    if recv_time > pinger.receive_timeout {
-                        break;
-                    }
-                    let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
-                    if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]){
-                        let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
-                        if let Some(icmp) = icmp_packet {
-                            let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
-                            match icmp.get_icmp_type() {
-                                IcmpTypes::EchoReply => {
-                                    let node = Node {
-                                        seq: seq,
-                                        ip_addr: ip_addr,
-                                        host_name: host_name.clone(),
-                                        hop: Some(sys::guess_initial_ttl(packet.get_ttl()) - packet.get_ttl()),
-                                        node_type: NodeType::Destination,
-                                        rtt: recv_time,
-                                    };
-                                    results.push(node.clone());
-                                    match tx.lock() {
-                                        Ok(lr) => {
-                                            match lr.send(node) {
-                                                Ok(_) => {},
-                                                Err(_) => {},
-                                            }
-                                        },
-                                        Err(_) => {},
-                                    }
-                                    break;
-                                },
-                                _ => {},
+            if let Ok((bytes_len, _addr)) = icmp_socket.recv_from(recv_buf) {
+                let recv_time = Instant::now().duration_since(send_time);
+                if recv_time > pinger.receive_timeout {
+                    break;
+                }
+                let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
+                if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]) {
+                    let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
+                    if let Some(icmp) = icmp_packet {
+                        let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
+                        if icmp.get_icmp_type() == IcmpTypes::EchoReply {
+                            let node = Node {
+                                seq,
+                                ip_addr,
+                                host_name: host_name.clone(),
+                                hop: Some(
+                                    sys::guess_initial_ttl(packet.get_ttl()) - packet.get_ttl(),
+                                ),
+                                node_type: NodeType::Destination,
+                                rtt: recv_time,
+                            };
+                            results.push(node.clone());
+                            if let Ok(lr) = tx.lock() {
+                                if lr.send(node).is_ok() {}
                             }
+                            break;
                         }
                     }
-                },
-                Err(_) => {},
+                }
             }
         }
         thread::sleep(pinger.send_rate);
     }
     let result: PingResult = PingResult {
-        results: results,
+        results,
         status: PingStatus::Done,
-        probe_time: probe_time,
+        probe_time,
     };
     Ok(result)
 }
 
 fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
-    let host_name: String = dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or(pinger.dst_ip.to_string());
+    let host_name: String =
+        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or_else(|_| pinger.dst_ip.to_string());
     let mut results: Vec<Node> = vec![];
     let socket_addr: SocketAddr = SocketAddr::new(pinger.dst_ip, pinger.dst_port);
     let sock_addr = SockAddr::from(socket_addr);
@@ -112,9 +102,9 @@ fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
         probe_time = Instant::now().duration_since(start_time);
         if probe_time > pinger.ping_timeout {
             let result: PingResult = PingResult {
-                results: results,
+                results,
                 status: PingStatus::Timeout,
-                probe_time: probe_time,
+                probe_time,
             };
             return Ok(result);
         }
@@ -124,7 +114,7 @@ fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
             Ok(_) => {
                 let connect_end_time = Instant::now().duration_since(connect_start_time);
                 let node = Node {
-                    seq: seq,
+                    seq,
                     ip_addr: pinger.dst_ip,
                     host_name: host_name.clone(),
                     hop: None,
@@ -132,57 +122,53 @@ fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
                     rtt: connect_end_time,
                 };
                 results.push(node.clone());
-                match tx.lock() {
-                    Ok(lr) => {
-                        match lr.send(node) {
-                            Ok(_) => {},
-                            Err(_) => {},
-                        }
-                    },
-                    Err(_) => {},
+                if let Ok(lr) = tx.lock() {
+                    if lr.send(node).is_ok() {}
                 }
-            },
+            }
             Err(e) => {
                 println!("{}", e);
-            },
+            }
         }
         thread::sleep(pinger.send_rate);
     }
     let result: PingResult = PingResult {
-        results: results,
+        results,
         status: PingStatus::Done,
-        probe_time: probe_time,
+        probe_time,
     };
     Ok(result)
 }
 
 fn udp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
-    let host_name: String = dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or(pinger.dst_ip.to_string());
+    let host_name: String =
+        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or_else(|_| pinger.dst_ip.to_string());
     let mut results: Vec<Node> = vec![];
     let udp_socket = match UdpSocket::bind("0.0.0.0:0") {
         Ok(s) => s,
         Err(e) => {
             return Err(format!("{}", e));
-        },
+        }
     };
-    let icmp_socket: Socket = 
-    if pinger.src_ip.is_ipv4() {
+    let icmp_socket: Socket = if pinger.src_ip.is_ipv4() {
         Socket::new(Domain::IPV4, Type::RAW, Some(Protocol::ICMPV4)).unwrap()
-    }else if pinger.src_ip.is_ipv6(){
+    } else if pinger.src_ip.is_ipv6() {
         Socket::new(Domain::IPV6, Type::RAW, Some(Protocol::ICMPV6)).unwrap()
-    }else{
+    } else {
         return Err(String::from("invalid source address"));
     };
-    icmp_socket.set_read_timeout(Some(pinger.receive_timeout)).unwrap();
+    icmp_socket
+        .set_read_timeout(Some(pinger.receive_timeout))
+        .unwrap();
     let start_time = Instant::now();
     let mut probe_time = Duration::from_millis(0);
     for seq in 1..pinger.count + 1 {
         probe_time = Instant::now().duration_since(start_time);
         if probe_time > pinger.ping_timeout {
             let result: PingResult = PingResult {
-                results: results,
+                results,
                 status: PingStatus::Timeout,
-                probe_time: probe_time,
+                probe_time,
             };
             return Ok(result);
         }
@@ -190,89 +176,71 @@ fn udp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
             Ok(_) => (),
             Err(e) => {
                 return Err(format!("{}", e));
-            },
+            }
         }
         let udp_buf = [0u8; 0];
         let mut buf: Vec<u8> = vec![0; 512];
-        let mut recv_buf = unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        let recv_buf = unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
         let dst: SocketAddr = SocketAddr::new(pinger.dst_ip, BASE_DST_PORT);
         let send_time = Instant::now();
         match udp_socket.send_to(&udp_buf, dst) {
             Ok(_) => (),
             Err(e) => {
                 return Err(format!("{}", e));
-            },
+            }
         }
-        loop{
+        loop {
             if Instant::now().duration_since(send_time) > pinger.receive_timeout {
                 break;
             }
-            match icmp_socket.recv_from(&mut recv_buf) {
-                Ok((bytes_len, _addr)) => {
-                    let recv_time = Instant::now().duration_since(send_time);
-                    let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
-                    if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]){
-                        let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
-                        if let Some(icmp) = icmp_packet {
-                            let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
-                            match icmp.get_icmp_type() {
-                                IcmpTypes::DestinationUnreachable => {
-                                    let node = Node {
-                                        seq: seq,
-                                        ip_addr: ip_addr,
-                                        host_name: host_name.clone(),
-                                        hop: Some(sys::guess_initial_ttl(packet.get_ttl()) - packet.get_ttl()),
-                                        node_type: NodeType::Destination,
-                                        rtt: recv_time,
-                                    };
-                                    results.push(node.clone());
-                                    match tx.lock() {
-                                        Ok(lr) => {
-                                            match lr.send(node) {
-                                                Ok(_) => {},
-                                                Err(_) => {},
-                                            }
-                                        },
-                                        Err(_) => {},
-                                    }
-                                    break;
-                                },
-                                _ => {},
+            if let Ok((bytes_len, _addr)) = icmp_socket.recv_from(recv_buf) {
+                let recv_time = Instant::now().duration_since(send_time);
+                let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
+                if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]) {
+                    let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
+                    if let Some(icmp) = icmp_packet {
+                        let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
+                        if icmp.get_icmp_type() == IcmpTypes::DestinationUnreachable {
+                            let node = Node {
+                                seq,
+                                ip_addr,
+                                host_name: host_name.clone(),
+                                hop: Some(
+                                    sys::guess_initial_ttl(packet.get_ttl()) - packet.get_ttl(),
+                                ),
+                                node_type: NodeType::Destination,
+                                rtt: recv_time,
+                            };
+                            results.push(node.clone());
+                            if let Ok(lr) = tx.lock() {
+                                if lr.send(node).is_ok() {}
                             }
+                            break;
                         }
                     }
-                },
-                Err(_) => {},
+                }
             }
         }
         thread::sleep(pinger.send_rate);
     }
     for node in &mut results {
-        let host_name: String = dns_lookup::lookup_addr(&node.ip_addr).unwrap_or(node.ip_addr.to_string());
+        let host_name: String =
+            dns_lookup::lookup_addr(&node.ip_addr).unwrap_or_else(|_| node.ip_addr.to_string());
         node.host_name = host_name;
     }
     let result: PingResult = PingResult {
-        results: results,
+        results,
         status: PingStatus::Done,
-        probe_time: probe_time,
+        probe_time,
     };
     Ok(result)
 }
 
 pub(crate) fn ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
     match pinger.protocol {
-        ProbeProtocol::Icmpv4 => {
-            icmp_ping(pinger, tx)
-        },
-        ProbeProtocol::Icmpv6 => {
-            icmp_ping(pinger, tx)
-        },
-        ProbeProtocol::Tcp => {
-            tcp_ping(pinger, tx)
-        },
-        ProbeProtocol::Udp => {
-            udp_ping(pinger, tx)
-        },
+        ProbeProtocol::Icmpv4 => icmp_ping(pinger, tx),
+        ProbeProtocol::Icmpv6 => icmp_ping(pinger, tx),
+        ProbeProtocol::Tcp => tcp_ping(pinger, tx),
+        ProbeProtocol::Udp => udp_ping(pinger, tx),
     }
 }
-

--- a/src/ping/windows.rs
+++ b/src/ping/windows.rs
@@ -13,8 +13,10 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use winapi::shared::ws2def::{AF_INET, AF_INET6, IPPROTO_IP};
-use winapi::um::winsock2::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
+// use winapi::shared::ws2def::{AF_INET, AF_INET6, IPPROTO_IP};
+use windows_sys::Win32::Networking::WinSock::{AF_INET, AF_INET6, IPPROTO_IP};
+// use winapi::um::winsock2::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
+use windows_sys::Win32::Networking::WinSock::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
 
 fn icmp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
     let host_name: String =
@@ -153,9 +155,9 @@ fn udp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
         }
     };
     let socket: SOCKET = if pinger.src_ip.is_ipv4() {
-        sys::create_socket(AF_INET, SOCK_RAW, IPPROTO_IP).unwrap()
+        sys::create_socket(AF_INET as i32, SOCK_RAW as i32, IPPROTO_IP as i32).unwrap()
     } else if pinger.src_ip.is_ipv6() {
-        sys::create_socket(AF_INET6, SOCK_RAW, IPPROTO_IP).unwrap()
+        sys::create_socket(AF_INET as i32, SOCK_RAW as i32, IPPROTO_IP as i32).unwrap()
     } else {
         return Err(String::from("invalid source address"));
     };
@@ -165,8 +167,8 @@ fn udp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
     sys::set_promiscuous(socket, true).unwrap();
     sys::set_timeout_opt(
         socket,
-        SOL_SOCKET,
-        SO_RCVTIMEO,
+        SOL_SOCKET as i32,
+        SO_RCVTIMEO as i32,
         Some(pinger.receive_timeout),
     )
     .unwrap();

--- a/src/ping/windows.rs
+++ b/src/ping/windows.rs
@@ -18,7 +18,7 @@ use winapi::um::winsock2::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
 
 fn icmp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
     let host_name: String =
-        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or(pinger.dst_ip.to_string());
+        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or_else(|_| pinger.dst_ip.to_string());
     let mut results: Vec<Node> = vec![];
     let icmp_socket: Socket = if pinger.src_ip.is_ipv4() {
         Socket::new(Domain::IPV4, Type::RAW, Some(Protocol::ICMPV4)).unwrap()
@@ -33,71 +33,53 @@ fn icmp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult
     icmp_socket.set_ttl(pinger.ttl as u32).unwrap();
     let socket_addr = SocketAddr::new(pinger.dst_ip, 0);
     let sock_addr = SockAddr::from(socket_addr);
-    let mut icmp_packet: Vec<u8> = packet::build_icmpv4_echo_packet();
+    let icmp_packet: Vec<u8> = packet::build_icmpv4_echo_packet();
     let start_time = Instant::now();
     let mut probe_time = Duration::from_millis(0);
     for seq in 1..pinger.count + 1 {
         probe_time = Instant::now().duration_since(start_time);
         if probe_time > pinger.ping_timeout {
             let result: PingResult = PingResult {
-                results: results,
+                results,
                 status: PingStatus::Timeout,
-                probe_time: probe_time,
+                probe_time,
             };
             return Ok(result);
         }
         let mut buf: Vec<u8> = vec![0; 512];
-        let mut recv_buf =
-            unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        let recv_buf = unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
         let send_time = Instant::now();
-        match icmp_socket.send_to(&mut icmp_packet, &sock_addr) {
-            Ok(_) => {}
-            Err(_) => {}
-        }
+        if icmp_socket.send_to(&icmp_packet, &sock_addr).is_ok() {}
         loop {
-            match icmp_socket.recv_from(&mut recv_buf) {
-                Ok((bytes_len, _addr)) => {
-                    let recv_time = Instant::now().duration_since(send_time);
-                    if recv_time > pinger.receive_timeout {
-                        break;
-                    }
-                    let recv_buf =
-                        unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
-                    if let Some(packet) =
-                        pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len])
-                    {
-                        let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
-                        if let Some(icmp) = icmp_packet {
-                            let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
-                            match icmp.get_icmp_type() {
-                                IcmpTypes::EchoReply => {
-                                    let node = Node {
-                                        seq,
-                                        ip_addr,
-                                        host_name: host_name.clone(),
-                                        hop: Some(
-                                            sys::guess_initial_ttl(packet.get_ttl())
-                                                - packet.get_ttl(),
-                                        ),
-                                        node_type: NodeType::Destination,
-                                        rtt: recv_time,
-                                    };
-                                    results.push(node.clone());
-                                    match tx.lock() {
-                                        Ok(lr) => match lr.send(node) {
-                                            Ok(_) => {}
-                                            Err(_) => {}
-                                        },
-                                        Err(_) => {}
-                                    }
-                                    break;
-                                }
-                                _ => {}
+            if let Ok((bytes_len, _addr)) = icmp_socket.recv_from(recv_buf) {
+                let recv_time = Instant::now().duration_since(send_time);
+                if recv_time > pinger.receive_timeout {
+                    break;
+                }
+                let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
+                if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]) {
+                    let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
+                    if let Some(icmp) = icmp_packet {
+                        let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
+                        if icmp.get_icmp_type() == IcmpTypes::EchoReply {
+                            let node = Node {
+                                seq,
+                                ip_addr,
+                                host_name: host_name.clone(),
+                                hop: Some(
+                                    sys::guess_initial_ttl(packet.get_ttl()) - packet.get_ttl(),
+                                ),
+                                node_type: NodeType::Destination,
+                                rtt: recv_time,
+                            };
+                            results.push(node.clone());
+                            if let Ok(lr) = tx.lock() {
+                                if lr.send(node).is_ok() {}
                             }
+                            break;
                         }
                     }
                 }
-                Err(_) => {}
             }
         }
         thread::sleep(pinger.send_rate);
@@ -112,7 +94,7 @@ fn icmp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult
 
 fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
     let host_name: String =
-        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or(pinger.dst_ip.to_string());
+        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or_else(|_| pinger.dst_ip.to_string());
     let mut results: Vec<Node> = vec![];
     let socket_addr: SocketAddr = SocketAddr::new(pinger.dst_ip, pinger.dst_port);
     let sock_addr = SockAddr::from(socket_addr);
@@ -134,7 +116,7 @@ fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
             Ok(_) => {
                 let connect_end_time = Instant::now().duration_since(connect_start_time);
                 let node = Node {
-                    seq: seq,
+                    seq,
                     ip_addr: pinger.dst_ip,
                     host_name: host_name.clone(),
                     hop: None,
@@ -142,12 +124,8 @@ fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
                     rtt: connect_end_time,
                 };
                 results.push(node.clone());
-                match tx.lock() {
-                    Ok(lr) => match lr.send(node) {
-                        Ok(_) => {}
-                        Err(_) => {}
-                    },
-                    Err(_) => {}
+                if let Ok(lr) = tx.lock() {
+                    if lr.send(node).is_ok() {}
                 }
             }
             Err(e) => {
@@ -166,7 +144,7 @@ fn tcp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
 
 fn udp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult, String> {
     let host_name: String =
-        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or(pinger.dst_ip.to_string());
+        dns_lookup::lookup_addr(&pinger.dst_ip).unwrap_or_else(|_| pinger.dst_ip.to_string());
     let mut results: Vec<Node> = vec![];
     let udp_socket = match UdpSocket::bind("0.0.0.0:0") {
         Ok(s) => s,
@@ -225,53 +203,39 @@ fn udp_ping(pinger: Pinger, tx: &Arc<Mutex<Sender<Node>>>) -> Result<PingResult,
             if Instant::now().duration_since(send_time) > pinger.receive_timeout {
                 break;
             }
-            match sys::recv_from(socket, recv_buf, 0) {
-                Ok((bytes_len, addr)) => {
-                    let src_addr: IpAddr = addr
-                        .as_socket()
-                        .unwrap_or(SocketAddr::new(pinger.src_ip, 0))
-                        .ip();
-                    if pinger.src_ip == src_addr {
-                        continue;
-                    }
-                    let recv_time = Instant::now().duration_since(send_time);
-                    let recv_buf =
-                        unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
-                    if let Some(packet) =
-                        pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len])
-                    {
-                        let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
-                        if let Some(icmp) = icmp_packet {
-                            let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
-                            match icmp.get_icmp_type() {
-                                IcmpTypes::DestinationUnreachable => {
-                                    let node = Node {
-                                        seq,
-                                        ip_addr,
-                                        host_name: host_name.clone(),
-                                        hop: Some(
-                                            sys::guess_initial_ttl(packet.get_ttl())
-                                                - packet.get_ttl(),
-                                        ),
-                                        node_type: NodeType::Destination,
-                                        rtt: recv_time,
-                                    };
-                                    results.push(node.clone());
-                                    match tx.lock() {
-                                        Ok(lr) => match lr.send(node) {
-                                            Ok(_) => {}
-                                            Err(_) => {}
-                                        },
-                                        Err(_) => {}
-                                    }
-                                    break;
-                                }
-                                _ => {}
+            if let Ok((bytes_len, addr)) = sys::recv_from(socket, recv_buf, 0) {
+                let src_addr: IpAddr = addr
+                    .as_socket()
+                    .unwrap_or_else(|| SocketAddr::new(pinger.src_ip, 0))
+                    .ip();
+                if pinger.src_ip == src_addr {
+                    continue;
+                }
+                let recv_time = Instant::now().duration_since(send_time);
+                let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
+                if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]) {
+                    let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
+                    if let Some(icmp) = icmp_packet {
+                        let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
+                        if icmp.get_icmp_type() == IcmpTypes::DestinationUnreachable {
+                            let node = Node {
+                                seq,
+                                ip_addr,
+                                host_name: host_name.clone(),
+                                hop: Some(
+                                    sys::guess_initial_ttl(packet.get_ttl()) - packet.get_ttl(),
+                                ),
+                                node_type: NodeType::Destination,
+                                rtt: recv_time,
+                            };
+                            results.push(node.clone());
+                            if let Ok(lr) = tx.lock() {
+                                if lr.send(node).is_ok() {}
                             }
-                        }
+                            break;
+                        };
                     }
                 }
-                Err(_) => {}
             }
         }
         thread::sleep(pinger.send_rate);

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,14 +1,14 @@
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 pub(crate) mod windows;
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 pub(crate) use self::windows::*;
 
 pub(crate) fn guess_initial_ttl(ttl: u8) -> u8 {
     if ttl <= 64 {
         64
-    }else if 64 < ttl && ttl <= 128 {
+    } else if 64 < ttl && ttl <= 128 {
         128
-    }else {
+    } else {
         255
     }
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -1,7 +1,7 @@
 use socket2::SockAddr;
 use std::cmp::min;
 use std::io;
-use std::mem::{self, size_of, MaybeUninit};
+use std::mem::{self, MaybeUninit};
 use std::net::UdpSocket;
 use std::ptr;
 use std::sync::Once;
@@ -13,7 +13,7 @@ use winapi::shared::mstcpip::SIO_RCVALL;
 use winapi::um::winbase::INFINITE;
 use winapi::um::winsock2::{self as sock, u_long, SOCKET, WSA_FLAG_NO_HANDLE_INHERIT};
 
-pub(crate) const NO_INHERIT: c_int = 1 << ((size_of::<c_int>() * 8) - 1);
+pub(crate) const NO_INHERIT: c_int = 1 << (c_int::BITS - 1);
 pub(crate) const MAX_BUF_LEN: usize = <c_int>::max_value() as usize;
 
 #[allow(unused_macros)]

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -1,17 +1,17 @@
-use std::time::Duration;
-use std::net::UdpSocket;
-use std::mem::{self, size_of, MaybeUninit};
 use socket2::SockAddr;
 use std::cmp::min;
+use std::io;
+use std::mem::{self, size_of, MaybeUninit};
+use std::net::UdpSocket;
 use std::ptr;
 use std::sync::Once;
-use std::io;
+use std::time::Duration;
 use winapi::ctypes::c_int;
 use winapi::ctypes::c_long;
-use winapi::shared::mstcpip::SIO_RCVALL;
-use winapi::um::winsock2::{self as sock, u_long, SOCKET, WSA_FLAG_NO_HANDLE_INHERIT};
 use winapi::shared::minwindef::DWORD;
-use winapi::um::winbase::{INFINITE};
+use winapi::shared::mstcpip::SIO_RCVALL;
+use winapi::um::winbase::INFINITE;
+use winapi::um::winsock2::{self as sock, u_long, SOCKET, WSA_FLAG_NO_HANDLE_INHERIT};
 
 pub(crate) const NO_INHERIT: c_int = 1 << ((size_of::<c_int>() * 8) - 1);
 pub(crate) const MAX_BUF_LEN: usize = <c_int>::max_value() as usize;

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -6,12 +6,26 @@ use std::net::UdpSocket;
 use std::ptr;
 use std::sync::Once;
 use std::time::Duration;
+
+/*
 use winapi::ctypes::c_int;
 use winapi::ctypes::c_long;
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::mstcpip::SIO_RCVALL;
 use winapi::um::winbase::INFINITE;
 use winapi::um::winsock2::{self as sock, u_long, SOCKET, WSA_FLAG_NO_HANDLE_INHERIT};
+*/
+
+#[allow(non_camel_case_types)]
+type c_int = i32;
+#[allow(non_camel_case_types)]
+type c_long = i32;
+type DWORD = u32;
+use windows_sys::Win32::Networking::WinSock::SIO_RCVALL;
+use windows_sys::Win32::System::WindowsProgramming::INFINITE;
+#[allow(non_camel_case_types)]
+type u_long = u32;
+use windows_sys::Win32::Networking::WinSock::{self as sock, SOCKET, WSA_FLAG_NO_HANDLE_INHERIT};
 
 pub(crate) const NO_INHERIT: c_int = 1 << (c_int::BITS - 1);
 pub(crate) const MAX_BUF_LEN: usize = <c_int>::max_value() as usize;

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -1,23 +1,23 @@
-#[cfg(not(target_os="windows"))]
+#[cfg(not(target_os = "windows"))]
 mod unix;
-#[cfg(not(target_os="windows"))]
+#[cfg(not(target_os = "windows"))]
 use unix::trace_route;
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 mod windows;
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 use self::windows::trace_route;
 
 mod tracer;
 pub use tracer::*;
 
-use std::time::Duration;
 use crate::node::Node;
+use std::time::Duration;
 
 /// Exit status of traceroute
 #[derive(Clone, Debug)]
 pub enum TraceStatus {
-    /// Successfully completed 
+    /// Successfully completed
     Done,
     /// Interrupted by error
     Error,

--- a/src/trace/tracer.rs
+++ b/src/trace/tracer.rs
@@ -1,14 +1,14 @@
-use std::net::IpAddr;
-use std::time::Duration;
-use std::sync::{Mutex, Arc};
-use std::sync::mpsc::{channel ,Sender, Receiver};
 use super::TraceResult;
 use crate::node::Node;
+use std::net::IpAddr;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 pub(crate) const BASE_DST_PORT: u16 = 33435;
 
 /// Tracer structure
-/// 
+///
 /// Contains various settings for traceroute
 #[derive(Clone, Debug)]
 pub struct Tracer {
@@ -33,22 +33,19 @@ pub struct Tracer {
 impl Tracer {
     /// Create new Tracer instance with destination IP address
     pub fn new(dst_ip: IpAddr) -> Result<Tracer, String> {
-        match default_net::get_default_interface(){
+        match default_net::get_default_interface() {
             Ok(interface) => {
-                let src_ip: IpAddr = 
-                if interface.ipv4.len() > 0 {
+                let src_ip: IpAddr = if !interface.ipv4.is_empty() {
                     IpAddr::V4(interface.ipv4[0].addr)
-                }else{
-                    if interface.ipv6.len() > 0 {
-                        IpAddr::V6(interface.ipv6[0].addr)
-                    }else{
-                        return Err(String::from("Failed to get default interface"));
-                    }
+                } else if !interface.ipv6.is_empty() {
+                    IpAddr::V6(interface.ipv6[0].addr)
+                } else {
+                    return Err(String::from("Failed to get default interface"));
                 };
                 let (tx, rx) = channel();
                 let tracer = Tracer {
-                    src_ip: src_ip,
-                    dst_ip: dst_ip,
+                    src_ip,
+                    dst_ip,
                     max_hop: 64,
                     trace_timeout: Duration::from_millis(30000),
                     receive_timeout: Duration::from_millis(1000),
@@ -56,11 +53,9 @@ impl Tracer {
                     tx: Arc::new(Mutex::new(tx)),
                     rx: Arc::new(Mutex::new(rx)),
                 };
-                return Ok(tracer);
-            },
-            Err(e) => {
-                return Err(format!("{}",e));
-            },
+                Ok(tracer)
+            }
+            Err(e) => Err(e),
         }
     }
     /// Trace route to destination
@@ -68,7 +63,7 @@ impl Tracer {
         super::trace_route(self.clone(), &self.tx)
     }
     /// Set source IP address
-    pub fn set_src_ip(&mut self, src_ip: IpAddr){
+    pub fn set_src_ip(&mut self, src_ip: IpAddr) {
         self.src_ip = src_ip;
     }
     /// Get source IP address
@@ -76,7 +71,7 @@ impl Tracer {
         self.src_ip
     }
     /// Set destination IP address
-    pub fn set_dst_ip(&mut self, dst_ip: IpAddr){
+    pub fn set_dst_ip(&mut self, dst_ip: IpAddr) {
         self.dst_ip = dst_ip;
     }
     /// Get destination IP address
@@ -84,7 +79,7 @@ impl Tracer {
         self.dst_ip
     }
     /// Set max hop
-    pub fn set_max_hop(&mut self, max_hop: u8){
+    pub fn set_max_hop(&mut self, max_hop: u8) {
         self.max_hop = max_hop;
     }
     /// Get max hop
@@ -92,7 +87,7 @@ impl Tracer {
         self.max_hop
     }
     /// Set traceroute timeout
-    pub fn set_trace_timeout(&mut self, trace_timeout: Duration){
+    pub fn set_trace_timeout(&mut self, trace_timeout: Duration) {
         self.trace_timeout = trace_timeout;
     }
     /// Get traceroute timeout
@@ -100,7 +95,7 @@ impl Tracer {
         self.trace_timeout
     }
     /// Set packet receive timeout
-    pub fn set_receive_timeout(&mut self, receive_timeout: Duration){
+    pub fn set_receive_timeout(&mut self, receive_timeout: Duration) {
         self.receive_timeout = receive_timeout;
     }
     /// Get packet receive timeout
@@ -108,7 +103,7 @@ impl Tracer {
         self.receive_timeout
     }
     /// Set packet send rate
-    pub fn set_send_rate(&mut self, send_rate: Duration){
+    pub fn set_send_rate(&mut self, send_rate: Duration) {
         self.send_rate = send_rate;
     }
     /// Get packet send rate

--- a/src/trace/unix.rs
+++ b/src/trace/unix.rs
@@ -1,35 +1,39 @@
-use std::net::IpAddr;
-use std::time::{Instant, Duration};
-use socket2::{Domain, Protocol, Socket, Type};
-use std::mem::MaybeUninit;
-use std::net::{SocketAddr, UdpSocket};
-use std::collections::HashSet;
-use std::thread;
-use std::sync::{Mutex, Arc};
-use std::sync::mpsc::Sender;
-use pnet_packet::Packet;
-use pnet_packet::icmp::IcmpTypes;
-use crate::node::{NodeType, Node};
-use super::{Tracer, TraceStatus, TraceResult};
 use super::BASE_DST_PORT;
+use super::{TraceResult, TraceStatus, Tracer};
+use crate::node::{Node, NodeType};
+use pnet_packet::icmp::IcmpTypes;
+use pnet_packet::Packet;
+use socket2::{Domain, Protocol, Socket, Type};
+use std::collections::HashSet;
+use std::mem::MaybeUninit;
+use std::net::IpAddr;
+use std::net::{SocketAddr, UdpSocket};
+use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
-pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Result<TraceResult, String> {
+pub(crate) fn trace_route(
+    tracer: Tracer,
+    tx: &Arc<Mutex<Sender<Node>>>,
+) -> Result<TraceResult, String> {
     let mut nodes: Vec<Node> = vec![];
     let udp_socket = match UdpSocket::bind("0.0.0.0:0") {
         Ok(s) => s,
         Err(e) => {
             return Err(format!("{}", e));
-        },
+        }
     };
-    let icmp_socket: Socket = 
-    if tracer.src_ip.is_ipv4() {
+    let icmp_socket: Socket = if tracer.src_ip.is_ipv4() {
         Socket::new(Domain::IPV4, Type::RAW, Some(Protocol::ICMPV4)).unwrap()
-    }else if tracer.src_ip.is_ipv6(){
+    } else if tracer.src_ip.is_ipv6() {
         Socket::new(Domain::IPV6, Type::RAW, Some(Protocol::ICMPV6)).unwrap()
-    }else{
+    } else {
         return Err(String::from("invalid source address"));
     };
-    icmp_socket.set_read_timeout(Some(tracer.receive_timeout)).unwrap();
+    icmp_socket
+        .set_read_timeout(Some(tracer.receive_timeout))
+        .unwrap();
     let mut ip_set: HashSet<IpAddr> = HashSet::new();
     let start_time = Instant::now();
     let mut trace_time = Duration::from_millis(0);
@@ -37,7 +41,7 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
         trace_time = Instant::now().duration_since(start_time);
         if trace_time > tracer.trace_timeout {
             let result: TraceResult = TraceResult {
-                nodes: nodes,
+                nodes,
                 status: TraceStatus::Timeout,
                 probe_time: trace_time,
             };
@@ -47,91 +51,85 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
             Ok(_) => (),
             Err(e) => {
                 return Err(format!("{}", e));
-            },
+            }
         }
         let udp_buf = [0u8; 0];
         let mut buf: Vec<u8> = vec![0; 512];
-        let mut recv_buf = unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        let recv_buf = unsafe { &mut *(buf.as_mut_slice() as *mut [u8] as *mut [MaybeUninit<u8>]) };
         let dst: SocketAddr = SocketAddr::new(tracer.dst_ip, BASE_DST_PORT + ttl as u16);
         let send_time = Instant::now();
         match udp_socket.send_to(&udp_buf, dst) {
             Ok(_) => (),
             Err(e) => {
                 return Err(format!("{}", e));
-            },
+            }
         }
-        match icmp_socket.recv_from(&mut recv_buf) {
-            Ok((bytes_len, addr)) => {
-                let src_addr: IpAddr = addr.as_socket().unwrap_or(SocketAddr::new(tracer.src_ip, 0)).ip();
-                if ip_set.contains(&src_addr) {
-                    continue;
-                }
-                let recv_time = Instant::now().duration_since(send_time);
-                let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
-                if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]){
-                    let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
-                    if let Some(icmp) = icmp_packet {
-                        let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
-                        match icmp.get_icmp_type() {
-                            IcmpTypes::TimeExceeded => {
-                                let node = Node {
-                                    seq: ttl,
-                                    ip_addr: ip_addr,
-                                    host_name: String::new(),
-                                    hop: Some(ttl),
-                                    node_type: if ttl == 1 {NodeType::DefaultGateway}else{NodeType::Relay},
-                                    rtt: recv_time,
-                                };
-                                nodes.push(node.clone());
-                                match tx.lock() {
-                                    Ok(lr) => {
-                                        match lr.send(node) {
-                                            Ok(_) => {},
-                                            Err(_) => {},
-                                        }
-                                    },
-                                    Err(_) => {},
-                                }
-                                ip_set.insert(ip_addr);
-                            },
-                            IcmpTypes::DestinationUnreachable => {
-                                let node = Node {
-                                    seq: ttl,
-                                    ip_addr: ip_addr,
-                                    host_name: String::new(),
-                                    hop: Some(ttl),
-                                    node_type: NodeType::Destination,
-                                    rtt: recv_time,
-                                };
-                                nodes.push(node.clone());
-                                match tx.lock() {
-                                    Ok(lr) => {
-                                        match lr.send(node) {
-                                            Ok(_) => {},
-                                            Err(_) => {},
-                                        }
-                                    },
-                                    Err(_) => {},
-                                }
-                                break;
-                            },
-                            _ => {},
+        if let Ok((bytes_len, addr)) = icmp_socket.recv_from(recv_buf) {
+            let src_addr: IpAddr = addr
+                .as_socket()
+                .unwrap_or_else(|| SocketAddr::new(tracer.src_ip, 0))
+                .ip();
+            if ip_set.contains(&src_addr) {
+                continue;
+            }
+            let recv_time = Instant::now().duration_since(send_time);
+            let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
+            if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]) {
+                let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
+                if let Some(icmp) = icmp_packet {
+                    let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
+                    match icmp.get_icmp_type() {
+                        IcmpTypes::TimeExceeded => {
+                            let node = Node {
+                                seq: ttl,
+                                ip_addr,
+                                host_name: String::new(),
+                                hop: Some(ttl),
+                                node_type: if ttl == 1 {
+                                    NodeType::DefaultGateway
+                                } else {
+                                    NodeType::Relay
+                                },
+                                rtt: recv_time,
+                            };
+                            nodes.push(node.clone());
+                            if let Ok(lr) = tx.lock() {
+                                if lr.send(node).is_ok() {}
+                            }
+
+                            ip_set.insert(ip_addr);
                         }
+                        IcmpTypes::DestinationUnreachable => {
+                            let node = Node {
+                                seq: ttl,
+                                ip_addr,
+                                host_name: String::new(),
+                                hop: Some(ttl),
+                                node_type: NodeType::Destination,
+                                rtt: recv_time,
+                            };
+                            nodes.push(node.clone());
+                            if let Ok(lr) = tx.lock() {
+                                if lr.send(node).is_ok() {}
+                            }
+                            break;
+                        }
+                        _ => {}
                     }
                 }
-            },
-            Err(_) => {},
+            }
         }
         thread::sleep(tracer.send_rate);
     }
     for node in &mut nodes {
-        let host_name: String = dns_lookup::lookup_addr(&node.ip_addr).unwrap_or(node.ip_addr.to_string());
+        let host_name: String =
+            dns_lookup::lookup_addr(&node.ip_addr).unwrap_or_else(|_| node.ip_addr.to_string());
         node.host_name = host_name;
     }
     let result: TraceResult = TraceResult {
-        nodes: nodes,
+        nodes,
         status: TraceStatus::Done,
         probe_time: trace_time,
     };
     Ok(result)
-} 
+}

--- a/src/trace/windows.rs
+++ b/src/trace/windows.rs
@@ -1,41 +1,49 @@
-use std::net::{IpAddr, SocketAddr, UdpSocket};
-use std::time::{Duration, Instant};
-use std::mem::MaybeUninit;
-use std::collections::HashSet;
-use std::thread;
-use std::sync::{Mutex, Arc};
-use std::sync::mpsc::Sender;
-use socket2::SockAddr;
+use super::BASE_DST_PORT;
+use super::{TraceResult, TraceStatus, Tracer};
+use crate::node::{Node, NodeType};
+use crate::sys;
+use pnet_packet::icmp::IcmpTypes;
 use pnet_packet::Packet;
-use pnet_packet::icmp::{IcmpTypes};
+use socket2::SockAddr;
+use std::collections::HashSet;
+use std::mem::MaybeUninit;
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 use winapi::shared::ws2def::{AF_INET, AF_INET6, IPPROTO_IP};
 use winapi::um::winsock2::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
-use super::{Tracer, TraceStatus, TraceResult};
-use super::BASE_DST_PORT;
-use crate::node::{NodeType, Node};
-use crate::sys;
 
-pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Result<TraceResult, String> {
+pub(crate) fn trace_route(
+    tracer: Tracer,
+    tx: &Arc<Mutex<Sender<Node>>>,
+) -> Result<TraceResult, String> {
     let mut nodes: Vec<Node> = vec![];
     let udp_socket = match UdpSocket::bind("0.0.0.0:0") {
         Ok(s) => s,
         Err(e) => {
             return Err(format!("{}", e));
-        },
+        }
     };
-    let socket: SOCKET = 
-    if tracer.src_ip.is_ipv4() {
+    let socket: SOCKET = if tracer.src_ip.is_ipv4() {
         sys::create_socket(AF_INET, SOCK_RAW, IPPROTO_IP).unwrap()
-    }else if tracer.src_ip.is_ipv6(){
+    } else if tracer.src_ip.is_ipv6() {
         sys::create_socket(AF_INET6, SOCK_RAW, IPPROTO_IP).unwrap()
-    }else{
+    } else {
         return Err(String::from("invalid source address"));
     };
     let socket_addr: SocketAddr = SocketAddr::new(tracer.src_ip, 0);
     let sock_addr = SockAddr::from(socket_addr);
     sys::bind(socket, &sock_addr).unwrap();
     sys::set_promiscuous(socket, true).unwrap();
-    sys::set_timeout_opt(socket, SOL_SOCKET, SO_RCVTIMEO, Some(tracer.receive_timeout)).unwrap();
+    sys::set_timeout_opt(
+        socket,
+        SOL_SOCKET,
+        SO_RCVTIMEO,
+        Some(tracer.receive_timeout),
+    )
+    .unwrap();
     let mut ip_set: HashSet<IpAddr> = HashSet::new();
     let mut end_trace: bool = false;
     let start_time = Instant::now();
@@ -57,7 +65,7 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
             Ok(_) => (),
             Err(e) => {
                 return Err(format!("{}", e));
-            },
+            }
         }
         let udp_buf = [0u8; 0];
         let dst: SocketAddr = SocketAddr::new(tracer.dst_ip, BASE_DST_PORT + ttl as u16);
@@ -68,7 +76,7 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
             Ok(_) => (),
             Err(e) => {
                 return Err(format!("{}", e));
-            },
+            }
         }
         loop {
             if Instant::now().duration_since(send_time) > tracer.receive_timeout {
@@ -76,13 +84,19 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
             }
             match sys::recv_from(socket, recv_buf, 0) {
                 Ok((bytes_len, addr)) => {
-                    let src_addr: IpAddr = addr.as_socket().unwrap_or(SocketAddr::new(tracer.src_ip, 0)).ip();
+                    let src_addr: IpAddr = addr
+                        .as_socket()
+                        .unwrap_or(SocketAddr::new(tracer.src_ip, 0))
+                        .ip();
                     if tracer.src_ip == src_addr || ip_set.contains(&src_addr) {
                         continue;
                     }
                     let recv_time = Instant::now().duration_since(send_time);
-                    let recv_buf = unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
-                    if let Some(packet) = pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len]){
+                    let recv_buf =
+                        unsafe { *(recv_buf as *mut [MaybeUninit<u8>] as *mut [u8; 512]) };
+                    if let Some(packet) =
+                        pnet_packet::ipv4::Ipv4Packet::new(&recv_buf[0..bytes_len])
+                    {
                         let icmp_packet = pnet_packet::icmp::IcmpPacket::new(packet.payload());
                         if let Some(icmp) = icmp_packet {
                             let ip_addr: IpAddr = IpAddr::V4(packet.get_source());
@@ -93,22 +107,24 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
                                         ip_addr: ip_addr,
                                         host_name: String::new(),
                                         hop: Some(ttl),
-                                        node_type: if ttl == 1 {NodeType::DefaultGateway}else{NodeType::Relay},
+                                        node_type: if ttl == 1 {
+                                            NodeType::DefaultGateway
+                                        } else {
+                                            NodeType::Relay
+                                        },
                                         rtt: recv_time,
                                     };
                                     nodes.push(node.clone());
                                     match tx.lock() {
-                                        Ok(lr) => {
-                                            match lr.send(node) {
-                                                Ok(_) => {},
-                                                Err(_) => {},
-                                            }
+                                        Ok(lr) => match lr.send(node) {
+                                            Ok(_) => {}
+                                            Err(_) => {}
                                         },
-                                        Err(_) => {},
+                                        Err(_) => {}
                                     }
                                     ip_set.insert(ip_addr);
                                     break;
-                                },
+                                }
                                 IcmpTypes::DestinationUnreachable => {
                                     let node = Node {
                                         seq: ttl,
@@ -120,29 +136,28 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
                                     };
                                     nodes.push(node.clone());
                                     match tx.lock() {
-                                        Ok(lr) => {
-                                            match lr.send(node) {
-                                                Ok(_) => {},
-                                                Err(_) => {},
-                                            }
+                                        Ok(lr) => match lr.send(node) {
+                                            Ok(_) => {}
+                                            Err(_) => {}
                                         },
-                                        Err(_) => {},
+                                        Err(_) => {}
                                     }
                                     end_trace = true;
                                     break;
-                                },
-                                _ => {},
+                                }
+                                _ => {}
                             }
                         }
                     }
-                },
-                Err(_) => {},
+                }
+                Err(_) => {}
             }
-        }   
+        }
         thread::sleep(tracer.send_rate);
     }
     for node in &mut nodes {
-        let host_name: String = dns_lookup::lookup_addr(&node.ip_addr).unwrap_or(node.ip_addr.to_string());
+        let host_name: String =
+            dns_lookup::lookup_addr(&node.ip_addr).unwrap_or(node.ip_addr.to_string());
         node.host_name = host_name;
     }
     let result: TraceResult = TraceResult {
@@ -151,4 +166,4 @@ pub(crate) fn trace_route(tracer: Tracer, tx: &Arc<Mutex<Sender<Node>>>) -> Resu
         probe_time: trace_time,
     };
     Ok(result)
-} 
+}

--- a/src/trace/windows.rs
+++ b/src/trace/windows.rs
@@ -12,8 +12,10 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use winapi::shared::ws2def::{AF_INET, AF_INET6, IPPROTO_IP};
-use winapi::um::winsock2::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
+// use winapi::shared::ws2def::{AF_INET, AF_INET6, IPPROTO_IP};
+use windows_sys::Win32::Networking::WinSock::{AF_INET, AF_INET6, IPPROTO_IP};
+// use winapi::um::winsock2::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
+use windows_sys::Win32::Networking::WinSock::{SOCKET, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO};
 
 pub(crate) fn trace_route(
     tracer: Tracer,
@@ -27,9 +29,9 @@ pub(crate) fn trace_route(
         }
     };
     let socket: SOCKET = if tracer.src_ip.is_ipv4() {
-        sys::create_socket(AF_INET, SOCK_RAW, IPPROTO_IP).unwrap()
+        sys::create_socket(AF_INET as i32, SOCK_RAW as i32, IPPROTO_IP as i32).unwrap()
     } else if tracer.src_ip.is_ipv6() {
-        sys::create_socket(AF_INET6, SOCK_RAW, IPPROTO_IP).unwrap()
+        sys::create_socket(AF_INET as i32, SOCK_RAW as i32, IPPROTO_IP as i32).unwrap()
     } else {
         return Err(String::from("invalid source address"));
     };
@@ -39,8 +41,8 @@ pub(crate) fn trace_route(
     sys::set_promiscuous(socket, true).unwrap();
     sys::set_timeout_opt(
         socket,
-        SOL_SOCKET,
-        SO_RCVTIMEO,
+        SOL_SOCKET as i32,
+        SO_RCVTIMEO as i32,
         Some(tracer.receive_timeout),
     )
     .unwrap();


### PR DESCRIPTION
- I have already made a pull to shift`dns-lookup` to `windows_sys` https://github.com/keeperofdakeys/dns-lookup/pull/23
- `socket2` is already on `windows_sys` and will have a major version change only https://github.com/rust-lang/socket2/issues/308