### PR TITLE
Refactor node/tracer naming and improve docs

### DIFF
--- a/examples/icmp_ping.rs
+++ b/examples/icmp_ping.rs
@@ -25,14 +25,20 @@ async fn main() {
     while !handle.is_finished() {
         let msg = rx.try_recv();
         if let Ok(msg) = msg {
-            println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+            println!(
+                "{} {} {:?} {:?}",
+                msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+            );
         } else {
             sleep(Duration::from_millis(20)).await;
         }
     }
 
     while let Ok(msg) = rx.try_recv() {
-        println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+        println!(
+            "{} {} {:?} {:?}",
+            msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+        );
     }
 
     println!("Result:");

--- a/examples/icmp_trace.rs
+++ b/examples/icmp_trace.rs
@@ -25,14 +25,20 @@ async fn main() {
     while !handle.is_finished() {
         let msg = rx.try_recv();
         if let Ok(msg) = msg {
-            println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+            println!(
+                "{} {} {:?} {:?}",
+                msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+            );
         } else {
             sleep(Duration::from_millis(20)).await;
         }
     }
 
     while let Ok(msg) = rx.try_recv() {
-        println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+        println!(
+            "{} {} {:?} {:?}",
+            msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+        );
     }
 
     println!("Result:");

--- a/examples/parallel_trace.rs
+++ b/examples/parallel_trace.rs
@@ -32,7 +32,7 @@ async fn main() {
                 if let Ok(msg) = rx.try_recv() {
                     println!(
                         "[{}] hop={} node={} rtt={:?}",
-                        dst_ip, msg.seq, msg.ip_addr, msg.rtt
+                        dst_ip, msg.sequence, msg.ip_addr, msg.rtt
                     );
                 } else {
                     sleep(Duration::from_millis(20)).await;
@@ -42,7 +42,7 @@ async fn main() {
             while let Ok(msg) = rx.try_recv() {
                 println!(
                     "[{}] hop={} node={} rtt={:?}",
-                    dst_ip, msg.seq, msg.ip_addr, msg.rtt
+                    dst_ip, msg.sequence, msg.ip_addr, msg.rtt
                 );
             }
 

--- a/examples/tcp_ping.rs
+++ b/examples/tcp_ping.rs
@@ -23,7 +23,7 @@ async fn main() {
         if let Ok(msg) = msg {
             println!(
                 "{} {}:{} {:?} {:?}",
-                msg.seq, msg.ip_addr, port, msg.hop, msg.rtt
+                msg.sequence, msg.ip_addr, port, msg.hop_count, msg.rtt
             );
         } else {
             sleep(Duration::from_millis(20)).await;
@@ -33,7 +33,7 @@ async fn main() {
     while let Ok(msg) = rx.try_recv() {
         println!(
             "{} {}:{} {:?} {:?}",
-            msg.seq, msg.ip_addr, port, msg.hop, msg.rtt
+            msg.sequence, msg.ip_addr, port, msg.hop_count, msg.rtt
         );
     }
 

--- a/examples/udp_ping.rs
+++ b/examples/udp_ping.rs
@@ -19,14 +19,20 @@ async fn main() {
     while !handle.is_finished() {
         let msg = rx.try_recv();
         if let Ok(msg) = msg {
-            println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+            println!(
+                "{} {} {:?} {:?}",
+                msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+            );
         } else {
             sleep(Duration::from_millis(20)).await;
         }
     }
 
     while let Ok(msg) = rx.try_recv() {
-        println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+        println!(
+            "{} {} {:?} {:?}",
+            msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+        );
     }
 
     println!("Result:");

--- a/examples/udp_trace.rs
+++ b/examples/udp_trace.rs
@@ -18,14 +18,20 @@ async fn main() {
     while !handle.is_finished() {
         let msg = rx.try_recv();
         if let Ok(msg) = msg {
-            println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+            println!(
+                "{} {} {:?} {:?}",
+                msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+            );
         } else {
             sleep(Duration::from_millis(20)).await;
         }
     }
 
     while let Ok(msg) = rx.try_recv() {
-        println!("{} {} {:?} {:?}", msg.seq, msg.ip_addr, msg.hop, msg.rtt);
+        println!(
+            "{} {} {:?} {:?}",
+            msg.sequence, msg.ip_addr, msg.hop_count, msg.rtt
+        );
     }
 
     println!("Result:");

--- a/src/node.rs
+++ b/src/node.rs
@@ -14,15 +14,15 @@ pub enum NodeType {
 #[derive(Clone, Debug)]
 pub struct Node {
     /// Probe sequence number
-    pub seq: u8,
+    pub sequence: u8,
     /// Node IP address
     pub ip_addr: IpAddr,
-    /// Resolved host name, or the IP string if reverse lookup fails
-    pub host_name: String,
+    /// Resolved hostname, or the IP string if reverse lookup fails
+    pub hostname: String,
     /// TTL value from the received packet
     pub ttl: Option<u8>,
     /// Hop count from the source
-    pub hop: Option<u8>,
+    pub hop_count: Option<u8>,
     /// Traceroute hop role
     pub node_type: NodeType,
     /// Round-trip time

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,32 +1,30 @@
 use std::net::IpAddr;
 use std::time::Duration;
 
-/// Node type
-#[derive(Clone, Debug, PartialEq)]
+/// Hop role in traceroute results.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NodeType {
-    /// Default gateway
-    DefaultGateway,
-    /// Relay node
-    Relay,
-    /// Destination host
+    /// Transit router (non-final hop)
+    Hop,
+    /// Final destination
     Destination,
 }
 
-/// Node structure
+/// Probe result for a single node.
 #[derive(Clone, Debug)]
 pub struct Node {
-    /// Sequence number
+    /// Probe sequence number
     pub seq: u8,
-    /// IP address
+    /// Node IP address
     pub ip_addr: IpAddr,
-    /// Host name
+    /// Resolved host name, or the IP string if reverse lookup fails
     pub host_name: String,
-    /// Time To Live
+    /// TTL value from the received packet
     pub ttl: Option<u8>,
-    /// Number of hops
+    /// Hop count from the source
     pub hop: Option<u8>,
-    /// Node type
+    /// Traceroute hop role
     pub node_type: NodeType,
-    /// Round Trip Time
+    /// Round-trip time
     pub rtt: Duration,
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,30 +1,30 @@
 use std::net::IpAddr;
 use std::time::Duration;
 
-/// Hop role in traceroute results.
+/// Role of a node in traceroute output.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NodeType {
-    /// Transit router (non-final hop)
+    /// Intermediate node on the route.
     Hop,
-    /// Final destination
+    /// Final destination node.
     Destination,
 }
 
-/// Probe result for a single node.
+/// Probe result for a single observed node.
 #[derive(Clone, Debug)]
 pub struct Node {
-    /// Probe sequence number
+    /// Sequence number of the probe.
     pub sequence: u8,
-    /// Node IP address
+    /// Node IP address.
     pub ip_addr: IpAddr,
-    /// Resolved hostname, or the IP string if reverse lookup fails
+    /// Resolved hostname, or the IP string if reverse lookup fails.
     pub hostname: String,
-    /// TTL value from the received packet
+    /// TTL value in the received packet, when available.
     pub ttl: Option<u8>,
-    /// Hop count from the source
+    /// Hop count from the source, when available.
     pub hop_count: Option<u8>,
-    /// Traceroute hop role
+    /// Node role classification.
     pub node_type: NodeType,
-    /// Round-trip time
+    /// Round-trip time.
     pub rtt: Duration,
 }

--- a/src/ping/mod.rs
+++ b/src/ping/mod.rs
@@ -6,25 +6,25 @@ pub(crate) use probe::ping;
 use crate::node::Node;
 use std::time::Duration;
 
-/// Exit status of ping
+/// Completion status of a ping run.
 #[derive(Clone, Debug)]
 pub enum PingStatus {
-    /// Successfully completed
+    /// Completed successfully.
     Done,
-    /// Interrupted by error
+    /// Ended due to an error.
     Error,
-    /// Execution time exceeds the configured timeout value
+    /// Stopped because execution exceeded the configured timeout.
     Timeout,
 }
 
-/// Result of ping
+/// Aggregated result of a ping run.
 #[derive(Clone, Debug)]
 pub struct PingResult {
-    /// Each ping results
+    /// Per-probe results.
     pub results: Vec<Node>,
-    /// Ping status
+    /// Completion status.
     pub status: PingStatus,
-    /// The entire ping probe time
+    /// Total probe time for the run.
     pub probe_time: Duration,
 }
 

--- a/src/ping/pinger.rs
+++ b/src/ping/pinger.rs
@@ -5,39 +5,35 @@ use std::net::IpAddr;
 use std::time::Duration;
 use tokio::sync::broadcast;
 
-/// Ping configuration and execution context.
-///
-/// Holds runtime settings used by ping probes.
+/// Configuration and execution context for ping probes.
 #[derive(Clone, Debug)]
 pub struct Pinger {
-    /// Source IP address
+    /// Source IP address used to send probes.
     pub src_ip: IpAddr,
-    /// Destination IP address
+    /// Destination IP address.
     pub dst_ip: IpAddr,
-    /// Destination port
+    /// Destination port for TCP/UDP probes.
     pub dst_port: u16,
-    /// Protocol used for ping
+    /// Protocol used to send probes.
     pub protocol: Protocol,
-    /// Time to live
-    ///
-    /// Default is 64
+    /// Time to live (TTL). Default is `64`.
     pub ttl: u8,
-    /// Number of probes to send
-    ///
-    /// Default is 4
+    /// Number of probes to send. Default is `4`.
     pub probe_count: u8,
-    /// Overall timeout for ping execution
+    /// Overall timeout for a full ping run.
     pub ping_timeout: Duration,
-    /// Timeout for receiving each packet
+    /// Timeout for receiving each probe response.
     pub receive_timeout: Duration,
-    /// Packet send interval
+    /// Delay between consecutive probes.
     pub send_interval: Duration,
-    /// Sender for progress messaging
+    /// Broadcast sender for per-probe progress events.
     pub progress_tx: broadcast::Sender<Node>,
 }
 
 impl Pinger {
-    /// Create a new pinger for the destination IP address
+    /// Creates a new `Pinger` for the destination address.
+    ///
+    /// The source address is inferred from the default interface.
     pub fn new(dst_ip: IpAddr) -> Result<Pinger, String> {
         match netdev::get_default_interface() {
             Ok(interface) => {
@@ -70,7 +66,7 @@ impl Pinger {
             }
         }
     }
-    /// Run ping synchronously
+    /// Runs ping synchronously.
     pub fn ping(&self) -> Result<PingResult, String> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_time()
@@ -78,83 +74,83 @@ impl Pinger {
             .map_err(|e| e.to_string())?;
         runtime.block_on(self.ping_async())
     }
-    /// Run ping asynchronously
+    /// Runs ping asynchronously.
     pub async fn ping_async(&self) -> Result<PingResult, String> {
         super::ping(self.clone(), &self.progress_tx).await
     }
-    /// Set source IP address
+    /// Sets the source IP address.
     pub fn set_src_ip(&mut self, src_ip: IpAddr) {
         self.src_ip = src_ip;
     }
-    /// Get source IP address
+    /// Returns the source IP address.
     pub fn get_src_ip(&self) -> IpAddr {
         self.src_ip
     }
-    /// Set destination IP address
+    /// Sets the destination IP address.
     pub fn set_dst_ip(&mut self, dst_ip: IpAddr) {
         self.dst_ip = dst_ip;
     }
-    /// Get destination IP address
+    /// Returns the destination IP address.
     pub fn get_dst_ip(&self) -> IpAddr {
         self.dst_ip
     }
-    /// Set destination port
+    /// Sets the destination port.
     pub fn set_dst_port(&mut self, dst_port: u16) {
         self.dst_port = dst_port;
     }
-    /// Get destination port
+    /// Returns the destination port.
     pub fn get_dst_port(&self) -> u16 {
         self.dst_port
     }
-    /// Set protocol
+    /// Sets the probe protocol.
     pub fn set_protocol(&mut self, protocol: Protocol) {
         self.protocol = protocol;
     }
-    /// Get protocol
+    /// Returns the probe protocol.
     pub fn get_protocol(&self) -> Protocol {
         self.protocol.clone()
     }
-    /// Set time to live
+    /// Sets the TTL value.
     pub fn set_ttl(&mut self, ttl: u8) {
         self.ttl = ttl;
     }
-    /// Get time to live
+    /// Returns the TTL value.
     pub fn get_ttl(&self) -> u8 {
         self.ttl
     }
-    /// Set probe count
+    /// Sets the number of probes to send.
     pub fn set_probe_count(&mut self, probe_count: u8) {
         self.probe_count = probe_count;
     }
-    /// Get probe count
+    /// Returns the number of probes to send.
     pub fn get_probe_count(&self) -> u8 {
         self.probe_count
     }
-    /// Set ping timeout
+    /// Sets the overall ping timeout.
     pub fn set_ping_timeout(&mut self, ping_timeout: Duration) {
         self.ping_timeout = ping_timeout;
     }
-    /// Get ping timeout
+    /// Returns the overall ping timeout.
     pub fn get_ping_timeout(&self) -> Duration {
         self.ping_timeout
     }
-    /// Set packet receive timeout
+    /// Sets the per-probe receive timeout.
     pub fn set_receive_timeout(&mut self, receive_timeout: Duration) {
         self.receive_timeout = receive_timeout;
     }
-    /// Get packet receive timeout
+    /// Returns the per-probe receive timeout.
     pub fn get_receive_timeout(&self) -> Duration {
         self.receive_timeout
     }
-    /// Set packet send interval
+    /// Sets the interval between probes.
     pub fn set_send_interval(&mut self, send_interval: Duration) {
         self.send_interval = send_interval;
     }
-    /// Get packet send interval
+    /// Returns the interval between probes.
     pub fn get_send_interval(&self) -> Duration {
         self.send_interval
     }
-    /// Get progress receiver
+    /// Returns a receiver for per-probe progress events.
     pub fn get_progress_receiver(&self) -> broadcast::Receiver<Node> {
         self.progress_tx.subscribe()
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,12 +1,12 @@
 /// Supported probe protocols.
 #[derive(Clone, Debug)]
 pub enum Protocol {
-    /// ICMPv4
+    /// Internet Control Message Protocol v4.
     Icmpv4,
-    /// ICMPv6
+    /// Internet Control Message Protocol v6.
     Icmpv6,
-    /// TCP
+    /// Transmission Control Protocol.
     Tcp,
-    /// UDP
+    /// User Datagram Protocol.
     Udp,
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,4 @@
-/// Protocol specification
+/// Supported probe protocols.
 #[derive(Clone, Debug)]
 pub enum Protocol {
     /// ICMPv4

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -6,24 +6,24 @@ pub use tracer::*;
 use crate::node::Node;
 use std::time::Duration;
 
-/// Exit status of traceroute
+/// Completion status of a traceroute run.
 #[derive(Clone, Debug)]
 pub enum TraceStatus {
-    /// Successfully completed
+    /// Completed successfully.
     Done,
-    /// Interrupted by error
+    /// Ended due to an error.
     Error,
-    /// Execution time exceeds the configured timeout value
+    /// Stopped because execution exceeded the configured timeout.
     Timeout,
 }
 
-/// Result of traceroute
+/// Aggregated result of a traceroute run.
 #[derive(Clone, Debug)]
 pub struct TraceResult {
-    /// Nodes to destination
+    /// Observed nodes along the route.
     pub nodes: Vec<Node>,
-    /// Traceroute status
+    /// Completion status.
     pub status: TraceStatus,
-    /// The entire traceroute time
+    /// Total probe time for the run.
     pub probe_time: Duration,
 }

--- a/src/trace/probe.rs
+++ b/src/trace/probe.rs
@@ -14,8 +14,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 
-fn send_progress(tx: &broadcast::Sender<Node>, node: Node) {
-    let _ = tx.send(node);
+fn send_progress(progress_tx: &broadcast::Sender<Node>, node: Node) {
+    let _ = progress_tx.send(node);
 }
 
 fn parse_trace_reply(
@@ -52,7 +52,10 @@ fn parse_trace_reply(
     None
 }
 
-async fn trace_icmp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<TraceResult, String> {
+async fn trace_icmp(
+    tracer: Tracer,
+    progress_tx: &broadcast::Sender<Node>,
+) -> Result<TraceResult, String> {
     let mut nodes: Vec<Node> = vec![];
     let mut ip_set: HashSet<IpAddr> = HashSet::new();
     let family = SocketFamily::from_ip(&tracer.dst_ip);
@@ -100,7 +103,7 @@ async fn trace_icmp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trac
             let src_addr = addr.ip();
             if ip_set.contains(&src_addr) {
                 if ttl != tracer.max_hop {
-                    tokio::time::sleep(tracer.send_rate).await;
+                    tokio::time::sleep(tracer.send_interval).await;
                 }
                 continue;
             }
@@ -109,11 +112,11 @@ async fn trace_icmp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trac
             {
                 let recv_time = Instant::now().duration_since(send_time);
                 let node = Node {
-                    seq: ttl,
+                    sequence: ttl,
                     ip_addr,
-                    host_name: ip_addr.to_string(),
+                    hostname: ip_addr.to_string(),
                     ttl: node_ttl,
-                    hop: Some(ttl),
+                    hop_count: Some(ttl),
                     node_type: if reached {
                         NodeType::Destination
                     } else {
@@ -122,7 +125,7 @@ async fn trace_icmp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trac
                     rtt: recv_time,
                 };
                 nodes.push(node.clone());
-                send_progress(tx, node);
+                send_progress(progress_tx, node);
                 ip_set.insert(ip_addr);
                 if reached {
                     break;
@@ -131,13 +134,13 @@ async fn trace_icmp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trac
         }
 
         if ttl != tracer.max_hop {
-            tokio::time::sleep(tracer.send_rate).await;
+            tokio::time::sleep(tracer.send_interval).await;
         }
     }
 
     for node in &mut nodes {
         if node.node_type == NodeType::Destination {
-            node.host_name =
+            node.hostname =
                 dns_lookup::lookup_addr(&node.ip_addr).unwrap_or_else(|_| node.ip_addr.to_string());
         }
     }
@@ -149,7 +152,10 @@ async fn trace_icmp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trac
     })
 }
 
-async fn trace_udp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<TraceResult, String> {
+async fn trace_udp(
+    tracer: Tracer,
+    progress_tx: &broadcast::Sender<Node>,
+) -> Result<TraceResult, String> {
     let mut nodes: Vec<Node> = vec![];
     let mut ip_set: HashSet<IpAddr> = HashSet::new();
     let family = SocketFamily::from_ip(&tracer.dst_ip);
@@ -207,7 +213,7 @@ async fn trace_udp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trace
             let src_addr = addr.ip();
             if ip_set.contains(&src_addr) {
                 if ttl != tracer.max_hop {
-                    tokio::time::sleep(tracer.send_rate).await;
+                    tokio::time::sleep(tracer.send_interval).await;
                 }
                 continue;
             }
@@ -217,11 +223,11 @@ async fn trace_udp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trace
             {
                 let recv_time = Instant::now().duration_since(send_time);
                 let node = Node {
-                    seq: ttl,
+                    sequence: ttl,
                     ip_addr,
-                    host_name: ip_addr.to_string(),
+                    hostname: ip_addr.to_string(),
                     ttl: node_ttl,
-                    hop: Some(ttl),
+                    hop_count: Some(ttl),
                     node_type: if reached {
                         NodeType::Destination
                     } else {
@@ -230,7 +236,7 @@ async fn trace_udp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trace
                     rtt: recv_time,
                 };
                 nodes.push(node.clone());
-                send_progress(tx, node);
+                send_progress(progress_tx, node);
                 ip_set.insert(ip_addr);
                 if reached {
                     break;
@@ -239,13 +245,13 @@ async fn trace_udp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trace
         }
 
         if ttl != tracer.max_hop {
-            tokio::time::sleep(tracer.send_rate).await;
+            tokio::time::sleep(tracer.send_interval).await;
         }
     }
 
     for node in &mut nodes {
         if node.node_type == NodeType::Destination {
-            node.host_name =
+            node.hostname =
                 dns_lookup::lookup_addr(&node.ip_addr).unwrap_or_else(|_| node.ip_addr.to_string());
         }
     }
@@ -261,11 +267,11 @@ async fn trace_udp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trace
 
 pub(crate) async fn trace_route(
     tracer: Tracer,
-    tx: &broadcast::Sender<Node>,
+    progress_tx: &broadcast::Sender<Node>,
 ) -> Result<TraceResult, String> {
     match tracer.protocol {
-        Protocol::Udp => trace_udp(tracer, tx).await,
-        Protocol::Icmpv4 | Protocol::Icmpv6 => trace_icmp(tracer, tx).await,
+        Protocol::Udp => trace_udp(tracer, progress_tx).await,
+        Protocol::Icmpv4 | Protocol::Icmpv6 => trace_icmp(tracer, progress_tx).await,
         Protocol::Tcp => Err(String::from("TCP traceroute is not supported")),
     }
 }

--- a/src/trace/probe.rs
+++ b/src/trace/probe.rs
@@ -116,10 +116,8 @@ async fn trace_icmp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trac
                     hop: Some(ttl),
                     node_type: if reached {
                         NodeType::Destination
-                    } else if ttl == 1 {
-                        NodeType::DefaultGateway
                     } else {
-                        NodeType::Relay
+                        NodeType::Hop
                     },
                     rtt: recv_time,
                 };
@@ -226,10 +224,8 @@ async fn trace_udp(tracer: Tracer, tx: &broadcast::Sender<Node>) -> Result<Trace
                     hop: Some(ttl),
                     node_type: if reached {
                         NodeType::Destination
-                    } else if ttl == 1 {
-                        NodeType::DefaultGateway
                     } else {
-                        NodeType::Relay
+                        NodeType::Hop
                     },
                     rtt: recv_time,
                 };

--- a/src/trace/tracer.rs
+++ b/src/trace/tracer.rs
@@ -7,31 +7,31 @@ use tokio::sync::broadcast;
 
 pub(crate) const BASE_DST_PORT: u16 = 33435;
 
-/// Tracer structure
-///
-/// Holds runtime settings used by traceroute probes.
+/// Configuration and execution context for traceroute probes.
 #[derive(Clone, Debug)]
 pub struct Tracer {
-    /// Source IP address
+    /// Source IP address used to send probes.
     pub src_ip: IpAddr,
-    /// Destination IP address
+    /// Destination IP address.
     pub dst_ip: IpAddr,
-    /// Protocol used for traceroute
+    /// Protocol used to send probes.
     pub protocol: Protocol,
-    /// Maximum hop count
+    /// Maximum hop count.
     pub max_hop: u8,
-    /// Overall timeout for traceroute execution
+    /// Overall timeout for a full traceroute run.
     pub trace_timeout: Duration,
-    /// Timeout for receiving each packet
+    /// Timeout for receiving each probe response.
     pub receive_timeout: Duration,
-    /// Packet send interval
+    /// Delay between consecutive probes.
     pub send_interval: Duration,
-    /// Sender for progress messaging
+    /// Broadcast sender for per-probe progress events.
     pub progress_tx: broadcast::Sender<Node>,
 }
 
 impl Tracer {
-    /// Create a new tracer for the destination IP address
+    /// Creates a new `Tracer` for the destination address.
+    ///
+    /// The source address is inferred from the default interface.
     pub fn new(dst_ip: IpAddr) -> Result<Tracer, String> {
         match netdev::get_default_interface() {
             Ok(interface) => {
@@ -62,7 +62,7 @@ impl Tracer {
             }
         }
     }
-    /// Run traceroute synchronously
+    /// Runs traceroute synchronously.
     pub fn trace(&self) -> Result<TraceResult, String> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_time()
@@ -70,67 +70,67 @@ impl Tracer {
             .map_err(|e| e.to_string())?;
         runtime.block_on(self.trace_async())
     }
-    /// Run traceroute asynchronously
+    /// Runs traceroute asynchronously.
     pub async fn trace_async(&self) -> Result<TraceResult, String> {
         super::trace_route(self.clone(), &self.progress_tx).await
     }
-    /// Set source IP address
+    /// Sets the source IP address.
     pub fn set_src_ip(&mut self, src_ip: IpAddr) {
         self.src_ip = src_ip;
     }
-    /// Get source IP address
+    /// Returns the source IP address.
     pub fn get_src_ip(&self) -> IpAddr {
         self.src_ip
     }
-    /// Set destination IP address
+    /// Sets the destination IP address.
     pub fn set_dst_ip(&mut self, dst_ip: IpAddr) {
         self.dst_ip = dst_ip;
     }
-    /// Get destination IP address
+    /// Returns the destination IP address.
     pub fn get_dst_ip(&self) -> IpAddr {
         self.dst_ip
     }
-    /// Set protocol
+    /// Sets the probe protocol.
     pub fn set_protocol(&mut self, protocol: Protocol) {
         self.protocol = protocol;
     }
-    /// Get protocol
+    /// Returns the probe protocol.
     pub fn get_protocol(&self) -> Protocol {
         self.protocol.clone()
     }
-    /// Set max hop
+    /// Sets the maximum hop count.
     pub fn set_max_hop(&mut self, max_hop: u8) {
         self.max_hop = max_hop;
     }
-    /// Get max hop
+    /// Returns the maximum hop count.
     pub fn get_max_hop(&self) -> u8 {
         self.max_hop
     }
-    /// Set traceroute timeout
+    /// Sets the overall traceroute timeout.
     pub fn set_trace_timeout(&mut self, trace_timeout: Duration) {
         self.trace_timeout = trace_timeout;
     }
-    /// Get traceroute timeout
+    /// Returns the overall traceroute timeout.
     pub fn get_trace_timeout(&self) -> Duration {
         self.trace_timeout
     }
-    /// Set packet receive timeout
+    /// Sets the per-probe receive timeout.
     pub fn set_receive_timeout(&mut self, receive_timeout: Duration) {
         self.receive_timeout = receive_timeout;
     }
-    /// Get packet receive timeout
+    /// Returns the per-probe receive timeout.
     pub fn get_receive_timeout(&self) -> Duration {
         self.receive_timeout
     }
-    /// Set packet send interval
+    /// Sets the interval between probes.
     pub fn set_send_interval(&mut self, send_interval: Duration) {
         self.send_interval = send_interval;
     }
-    /// Get packet send interval
+    /// Returns the interval between probes.
     pub fn get_send_interval(&self) -> Duration {
         self.send_interval
     }
-    /// Get progress receiver
+    /// Returns a receiver for per-probe progress events.
     pub fn get_progress_receiver(&self) -> broadcast::Receiver<Node> {
         self.progress_tx.subscribe()
     }


### PR DESCRIPTION
Refactors core probe/tracer naming for clarity and consistency, and improve docs.

- Simplified NodeType to Hop | Destination
- Renamed public fields for clearer semantics
- Renamed related methods
- Updated ping/trace internals and examples
- Updated documents

Note: Includes breaking changes to the public API.