### PR TITLE
Fix a tokio panic when calling Tracer::trace()

### DIFF
--- a/src/trace/tracer.rs
+++ b/src/trace/tracer.rs
@@ -66,6 +66,7 @@ impl Tracer {
     pub fn trace(&self) -> Result<TraceResult, String> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_time()
+            .enable_io()
             .build()
             .map_err(|e| e.to_string())?;
         runtime.block_on(self.trace_async())


### PR DESCRIPTION
Tokio panics in src/socket/udp.rs:88 when calling Tracer::trace(), because I/O is not enabled for the tokio runtime.
The panic was observed on macOS and iOS targets.
Adding `enable_io()` is required to enable tokio to use `net` and other I/O types on the runtime.

Fixes https://github.com/shellrow/tracert/issues/17